### PR TITLE
Scale overshoot fix

### DIFF
--- a/Editor/app.js
+++ b/Editor/app.js
@@ -193,12 +193,24 @@ window.addEventListener("keydown", (event) => {
     if (dragTarget) {
         // Scale with keyboard keys
         if (event.key === "+") {
-            dragTarget.scale.x >= 1 ? dragTarget.scale.x = 1 : dragTarget.scale.x += 0.1;
-            dragTarget.scale.y >= 1 ? dragTarget.scale.y = 1 : dragTarget.scale.y += 0.1;
+            if(dragTarget.scale.x + 0.1 > 1){
+                dragTarget.scale.x = 1;
+                dragTarget.scale.y = 1;
+            }
+            else {
+                dragTarget.scale.x += 0.1;
+                dragTarget.scale.y += 0.1;
+            }
             adjustVolume(dragTarget.id, 1);
         } else if (event.key === "-") {
-            dragTarget.scale.x <= 0.15 ? dragTarget.scale.x = 0.15 : dragTarget.scale.x -= 0.1;
-            dragTarget.scale.y <= 0.15 ? dragTarget.scale.y = 0.15 : dragTarget.scale.y -= 0.1;
+            if(dragTarget.scale.x - 0.1 < .15){
+                dragTarget.scale.x = .15;
+                dragTarget.scale.y = .15;
+            }
+            else {
+                dragTarget.scale.x -= 0.1;
+                dragTarget.scale.y -= 0.1;
+            }
             adjustVolume(dragTarget.id, -1);
         }
         else if(event.key === "Delete"){


### PR DESCRIPTION
I clamping the scale the way you did it, it allows for the user to overshoot the min and max scale.  Run yours and scale it all the way down, you'll see it jump back up a size if you keep trying to scale down.  This is why I changed it to check the math of the scale before setting instead of comparing directly to the scale and clamping off that.